### PR TITLE
Changes to add a new topic for light bar status based on front light bar

### DIFF
--- a/srx_controller/include/srx_controller/srx_application.h
+++ b/srx_controller/include/srx_controller/srx_application.h
@@ -119,6 +119,7 @@ private:
     ros::Subscriber effort_sub_, speed_sub_;
     ros::ServiceServer get_lights_srv_, set_lights_srv_, enable_robotic_srv_;
     ros::Publisher robotic_status_pub_;
+    ros::Publisher light_bar_status_pub_; //MF 02/2019: Added for light bar status topic
     std::shared_ptr<ros::NodeHandle> control_nh_;
     ros::WallTimer status_publisher_timer_;
 
@@ -267,6 +268,7 @@ private:
 
     /**
      * @brief Timer Callback that updates the robot_status topic
+     * MF 02/2019: Updated to include the lightbar status topic(s)
      */
     void statusUpdateTimerCB(const ros::WallTimerEvent &);
 

--- a/srx_controller/package.xml
+++ b/srx_controller/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>srx_controller</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>The srx_controller package</description>
   <maintainer email="support@torcrobotics.com">Torc Robotics</maintainer>
   <license>BSD</license>

--- a/srx_controller/readme.md
+++ b/srx_controller/readme.md
@@ -23,6 +23,9 @@ sent_messages ( can_msgs/Frame )
 /diagnostics (diagnostic_msgs/DiagnosticArray)
 > This driver uses the diagnostic_updater API to publish diagnostic statuses to the /diagnostic topic.
 
+/control/light_bar_status (cav_msgs/LightBarStatus)
+> This publishes the light bar status based on the front lights. Currently, the front and rear can be set once, and not separately. Therefore basing this status on the front light bar.
+
 ### Subscribed Topics
 received_messages ( can_msgs/Frame )
 > We listen to this topic for messages from the dbw module


### PR DESCRIPTION
Updated driver to add a new topic called /control/light_bar_status. Per discussion, will only based on the front light bar since there's only one service call to set both rear and front, and haven't any known issues with discrepancies with setting both. If there's are any discrepancies in the future, we will address later. 